### PR TITLE
Handle ‘keyed’ children - e.g. for AMaaS Models, the children are key…

### DIFF
--- a/amaasutils/case.py
+++ b/amaasutils/case.py
@@ -1,26 +1,64 @@
 """ Helper functions for converting string cases """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import re
 
 
-def dict_camel_to_snake_case(camel_dict):
+def dict_camel_to_snake_case(camel_dict, convert_keys=True, convert_subkeys=False):
     """
     Recursively convert camelCased keys for a camelCased dict into snake_cased keys
+
+    :param camel_dict: Dictionary to convert
+    :paran convert_keys: Whether the key should be converted
+    :param convert_subkeys: Whether to also convert the subkeys, in case they are named properties of the dict
+    :return:
     """
+
     converted = {}
     for key, value in camel_dict.items():
-        new_value = dict_camel_to_snake_case(value) if isinstance(value, dict) else value
-        converted[to_snake_case(key)] = new_value
+        if isinstance(value, dict):
+            new_value = dict_camel_to_snake_case(value, convert_keys=convert_subkeys,
+                                                 convert_subkeys=True)
+        elif isinstance(value, list):
+            new_value = []
+            for subvalue in value:
+                new_subvalue = dict_camel_to_snake_case(subvalue, convert_keys=convert_subkeys,
+                                                        convert_subkeys=True) \
+                    if isinstance(subvalue, dict) else subvalue
+                new_value.append(new_subvalue)
+        else:
+            new_value = value
+        new_key = to_snake_case(key) if convert_keys else key
+        converted[new_key] = new_value
     return converted
 
 
-def dict_snake_to_camel_case(snake_dict):
+def dict_snake_to_camel_case(snake_dict, convert_keys=True, convert_subkeys=False):
     """
     Recursively convert a snake_cased dict into a camelCased dict
+
+    :param snake_dict: Dictionary to convert
+    :param convert_keys: Whether the key should be converted
+    :param convert_subkeys: Whether to also convert the subkeys, in case they are named properties of the dict
+    :return:
     """
+
     converted = {}
     for key, value in snake_dict.items():
-        new_value = dict_snake_to_camel_case(value) if isinstance(value, dict) else value
-        converted[to_camel_case(key)] = new_value
+        if isinstance(value, dict):
+            new_value = dict_snake_to_camel_case(value, convert_keys=convert_subkeys,
+                                                 convert_subkeys=True)
+        elif isinstance(value, list):
+            new_value = []
+            for subvalue in value:
+                new_subvalue = dict_snake_to_camel_case(subvalue, convert_keys=convert_subkeys,
+                                                        convert_subkeys=True) \
+                    if isinstance(subvalue, dict) else subvalue
+                new_value.append(new_subvalue)
+        else:
+            new_value = value
+        new_key = to_camel_case(key) if convert_keys else key
+        converted[new_key] = new_value
     return converted
 
 

--- a/amaasutils/random_utils.py
+++ b/amaasutils/random_utils.py
@@ -1,9 +1,11 @@
 """ Helper functions for generating random data """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import date
 from decimal import Decimal
 import random
 import string
+
 
 def random_string(length):
     """

--- a/tests/case.py
+++ b/tests/case.py
@@ -8,6 +8,9 @@ from amaasutils.case import to_snake_case, dict_camel_to_snake_case, dict_snake_
 
 class CaseTest(unittest.TestCase):
 
+    def setUp(self):
+        self.maxDiff = None
+
     def test_ToSnakeCase(self):
         input_str = 'inputString'
         self.assertEqual(to_snake_case(input_str), 'input_string')
@@ -16,22 +19,69 @@ class CaseTest(unittest.TestCase):
         test_input = {'fieldOne': 'valueOne', 'fieldTwo': 'value_two',
                       'fieldThree': {'fieldThreeOne': 'valueThreeOne',
                                      'fieldThreeTwo': 'value_three_two'}}
-        test_json = json.loads(json.dumps(test_input)) # Convert to JSON formatting
-        test_output = dict_camel_to_snake_case(test_json)
+        test_json = json.loads(json.dumps(test_input))  # Convert to JSON formatting
+        test_output = dict_camel_to_snake_case(test_json, convert_subkeys=True)
         expected_output = {'field_one': 'valueOne', 'field_two': 'value_two',
-                           'field_three': {'field_three_one': u'valueThreeOne',
-                                           'field_three_two': u'value_three_two'}}
+                           'field_three': {'field_three_one': 'valueThreeOne',
+                                           'field_three_two': 'value_three_two'}}
         self.assertEqual(test_output, expected_output)
 
     def test_JsonSnakeToCamelCase(self):
         test_input = {'field_one': 'valueOne', 'field_two': 'value_two',
-                      'field_three': {'field_three_one': u'valueThreeOne',
-                                      'field_three_two': u'value_three_two'}}
-        test_json = json.loads(json.dumps(test_input)) # Convert to JSON formatting
+                      'field_three': {'field_three_one': 'valueThreeOne',
+                                      'field_three_two': 'value_three_two'}}
+        test_json = json.loads(json.dumps(test_input))  # Convert to JSON formatting
+        test_output = dict_snake_to_camel_case(test_json, convert_subkeys=True)
+        expected_output = {'fieldOne': 'valueOne', 'fieldTwo': 'value_two',
+                           'fieldThree': {'fieldThreeOne': 'valueThreeOne',
+                                          'fieldThreeTwo': 'value_three_two'}}
+        self.assertEqual(test_output, expected_output)
+
+    def test_KeyedChildrenCamelToSnakeCase(self):
+        test_input = {'fieldOne': 'valueOne', 'fieldTwo': 'value_two',
+                      'fieldThree': {'KeyOne': {'fieldThreeOneOne': 'valueThreeOne',
+                                                'fieldThreeOneTwo': 'value_three_two'},
+                                     'key_two': {'fieldThreeTwoOne': 'valueThreeOne',
+                                                 'fieldThreeTwoTwo': 'value_three_two'},
+                                     'keyThree': [{'fieldThreeThreeOneOne': 'valueThreeThreeOneOne',
+                                                   'fieldThreeThreeOneTwo': 'value_three_three_one_two'},
+                                                  {'fieldThreeThreeTwoOne': 'valueThreeThreeTwoOne',
+                                                   'fieldThreeThreeTwoTwo': 'value_three_three_two_two'}]}}
+        test_json = json.loads(json.dumps(test_input))  # Convert to JSON formatting
+        test_output = dict_camel_to_snake_case(test_json)
+        expected_output = {'field_one': 'valueOne', 'field_two': 'value_two',
+                           'field_three': {'KeyOne': {'field_three_one_one': 'valueThreeOne',
+                                                      'field_three_one_two': 'value_three_two'},
+                                           'key_two':
+                                               {'field_three_two_one': 'valueThreeOne',
+                                                'field_three_two_two': 'value_three_two'},
+                                           'keyThree': [{'field_three_three_one_one': 'valueThreeThreeOneOne',
+                                                         'field_three_three_one_two': 'value_three_three_one_two'},
+                                                        {'field_three_three_two_one': 'valueThreeThreeTwoOne',
+                                                         'field_three_three_two_two': 'value_three_three_two_two'}]}}
+        self.assertEqual(test_output, expected_output)
+
+    def test_KeyedChildrenSnakeToCamelCase(self):
+        test_input = {'field_one': 'valueOne', 'field_two': 'value_two',
+                      'field_three': {'KeyOne': {'field_three_one_one': 'valueThreeOneOne',
+                                                 'field_three_one_two': 'value_three_one_two'},
+                                      'key_two': {'field_three_two_one': 'valueThreeTwoOne',
+                                                  'field_three_two_two': 'value_three_two_two'},
+                                      'keyThree': [{'field_three_three_one_one': 'valueThreeThreeOneOne',
+                                                    'field_three_three_one_two': 'value_three_three_one_two'},
+                                                   {'field_three_three_two_one': 'valueThreeThreeTwoOne',
+                                                    'field_three_three_two_two': 'value_three_three_two_two'}]}}
+        test_json = json.loads(json.dumps(test_input))  # Convert to JSON formatting
         test_output = dict_snake_to_camel_case(test_json)
         expected_output = {'fieldOne': 'valueOne', 'fieldTwo': 'value_two',
-                           'fieldThree': {'fieldThreeOne': u'valueThreeOne',
-                                          'fieldThreeTwo': u'value_three_two'}}
+                           'fieldThree': {'KeyOne': {'fieldThreeOneOne': 'valueThreeOneOne',
+                                                     'fieldThreeOneTwo': 'value_three_one_two'},
+                                          'key_two': {'fieldThreeTwoOne': 'valueThreeTwoOne',
+                                                      'fieldThreeTwoTwo': 'value_three_two_two'},
+                                          'keyThree': [{'fieldThreeThreeOneOne': 'valueThreeThreeOneOne',
+                                                        'fieldThreeThreeOneTwo': 'value_three_three_one_two'},
+                                                       {'fieldThreeThreeTwoOne': 'valueThreeThreeTwoOne',
+                                                        'fieldThreeThreeTwoTwo': 'value_three_three_two_two'}]}}
         self.assertEqual(test_output, expected_output)
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ed dictionaries, and we don’t want to convert those keys.  Handle lists of children as well (e.g. for Links).  AMAAS-648.